### PR TITLE
Return nil instead of throwing AssertionError

### DIFF
--- a/src/valip/predicates.clj
+++ b/src/valip/predicates.clj
@@ -40,12 +40,12 @@
   invalid, as this syntax is not commonly supported in practise. The domain of
   the email address is not checked for validity."
   [email]
-  {:pre [(present? email)]}
-  (let [re (str "(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+"
-                "(?:\\.[a-z0-9!#$%&'*+/=?" "^_`{|}~-]+)*"
-                "@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+"
-                "[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")]
-    (boolean (re-matches (re-pattern re) email))))
+  (when (present? email)
+    (let [re (str "(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+"
+                  "(?:\\.[a-z0-9!#$%&'*+/=?" "^_`{|}~-]+)*"
+                  "@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+"
+                  "[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")]
+      (boolean (re-matches (re-pattern re) email)))))
 
 (defn- dns-lookup [^String hostname ^String type]
   (let [params {"java.naming.factory.initial"
@@ -60,71 +60,79 @@
 (defn valid-email-domain?
   "Returns true if the domain of the supplied email address has a MX DNS entry."
   [email]
-  {:pre [(email-address? email)]}
-  (if-let [domain (second (re-matches #".*@(.*)" email))]
-    (boolean (dns-lookup domain "MX"))))
+  (when (email-address? email)
+    (if-let [domain (second (re-matches #".*@(.*)" email))]
+      (boolean (dns-lookup domain "MX")))))
 
 (defn url?
   "Returns true if the string is a valid URL."
   [s]
-  {:pre [(present? s)]}
-  (try
-    (URL. s) true
-    (catch MalformedURLException _ false)))
+  (when (present? s)
+    (try
+      (URL. s) true
+      (catch MalformedURLException _ false))))
 
 (defn digits?
   "Returns true if a string consists only of numerical digits."
   [s]
-  {:pre [(present? s)]}
-  (boolean (re-matches #"\d+" s)))
+  (when (present? s)
+    (boolean (re-matches #"\d+" s))))
 
 (defn alphanumeric?
   "Returns true if a string consists only of alphanumeric characters."
   [s]
-  {:pre [(present? s)]}
-  (boolean (re-matches #"[A-Za-z0-9]+")))
+  (when (present? s)
+    (boolean (re-matches #"[A-Za-z0-9]+"))))
 
 (defn integer-string?
   "Returns true if the string represents an integer."
   [s]
-  {:pre [(present? s)]}
-  (boolean (.validate (IntegerValidator.) s)))
+  (when (present? s)
+    (boolean (.validate (IntegerValidator.) s))))
 
 (defn decimal-string?
   "Returns true if the string represents a decimal number."
   [s]
-  {:pre [(present? s)]}
-  (boolean (.validate (DoubleValidator.) s)))
+  (when (present? s)
+    (boolean (.validate (DoubleValidator.) s))))
 
 (defn- parse-number [x]
-  {:pre [(present? x)]}
-  (if (string? x)
-    (.validate (DoubleValidator.) x)
-    x))
+  (when (present? x)
+    (if (string? x)
+      (.validate (DoubleValidator.) x)
+      x)))
 
 (defn gt
   "Creates a predicate function for checking if a value is numerically greater
   than the specified number."
   [n]
-  (fn [x] (> (parse-number x) n)))
+  (fn [x]
+    (when (present? x)
+      (> (parse-number x) n))))
 
 (defn lt
   "Creates a predicate function for checking if a value is numerically less
   than the specified number."
   [n]
-  (fn [x] (< (parse-number x) n)))
+  (fn [x]
+    (when (present? x)
+      (< (parse-number x) n))))
 
 (defn gte
   "Creates a predicate function for checking if a value is numerically greater
   than or equal to the specified number."
   [n]
-  (fn [x] (>= (parse-number x) n)))
+  (fn [x]
+    (when (present? x)
+      (>= (parse-number x) n))))
 
 (defn lte
   "Creates a predicate function for checking if a value is numerically less
   than or equal to the specified number."
   [n]
-  (fn [x] (<= (parse-number x) n)))
+  (fn [x]
+    (when (present? x)
+      (<= (parse-number x) n))))
 
 (def ^{:doc "Alias for gt"} over gt)
 
@@ -139,8 +147,9 @@
   values (inclusive)."
   [min max]
   (fn [x]
-    (let [x (parse-number x)]
-      (and (>= x min) (<= x max)))))
+    (when (present? x)
+      (let [x (parse-number x)]
+        (and (>= x min) (<= x max))))))
 
 (defn- parse-date-time [format input]
   {:pre [(present? input)]}
@@ -148,11 +157,6 @@
     (try
       (time-format/parse formatter input)
       (catch IllegalArgumentException _ nil))))
-
-(defn date-format
-  "Creates a function for parsing a date using the supplied format string."
-  [format]
-  (partial parse-date-time format))
 
 (defn html5-date?
   "Returns true if the string is one that could be returned by a HTML5 date

--- a/test/valip/test/predicates.clj
+++ b/test/valip/test/predicates.clj
@@ -32,23 +32,23 @@
   (is (not (email-address? "foo@bar")))
   (is (not (email-address? "foo bar@example.com")))
   (is (not (email-address? "foo@foo_bar.com")))
-  (is (thrown? AssertionError (email-address? ""))))
+  (is (not (email-address? ""))))
 
 (deftest test-valid-email-domain?
   (is (valid-email-domain? "example@google.com"))
   (is (not (valid-email-domain? "foo@example.com")))
   (is (not (valid-email-domain? "foo@google.com.nospam")))
-  (is (thrown? AssertionError (valid-email-domain? "foo"))))
+  (is (not (valid-email-domain? "foo"))))
 
 (deftest test-url?
   (is (url? "http://google.com"))
   (is (not (url? "foobar")))
-  (is (thrown? AssertionError (url? ""))))
+  (is (not (url? ""))))
 
 (deftest test-digits?
   (is (digits? "01234"))
   (is (not (digits? "04xa")))
-  (is (thrown? AssertionError (digits? ""))))
+  (is (not (digits? ""))))
 
 (deftest test-integer-string?
   (is (integer-string? "10"))
@@ -59,7 +59,7 @@
   (is (not (integer-string? "foo")))
   (is (not (integer-string? "10x")))
   (is (not (integer-string? "1.1")))
-  (is (thrown? AssertionError (integer-string? ""))))
+  (is (not (integer-string? ""))))
 
 (deftest test-integer-string?
   (is (decimal-string? "10"))
@@ -71,31 +71,31 @@
   (is (decimal-string? "3.14159"))
   (is (not (decimal-string? "foo")))
   (is (not (decimal-string? "10x")))
-  (is (thrown? AssertionError (decimal-string? ""))))
+  (is (not (decimal-string? ""))))
 
 (deftest test-gt
   (is ((gt 10) "11"))
   (is (not ((gt 10) "9")))
   (is (not ((gt 10) "10")))
-  (is (thrown? AssertionError ((gt 10) ""))))
+  (is (not ((gt 10) ""))))
 
 (deftest test-gte
   (is ((gte 10) "11"))
   (is ((gte 10) "10"))
   (is (not ((gte 10) "9")))
-  (is (thrown? AssertionError ((gte 10) ""))))
+  (is (not ((gte 10) ""))))
 
 (deftest test-lt
   (is ((lt 10) "9"))
   (is (not ((lt 10) "11")))
   (is (not ((lt 10) "10")))
-  (is (thrown? AssertionError ((lt 10) ""))))
+  (is (not ((lt 10) ""))))
 
 (deftest test-lte
   (is ((lte 10) "9"))
   (is ((lte 10) "10"))
   (is (not ((lte 10) "11")))
-  (is (thrown? AssertionError ((lte 10) ""))))
+  (is (not ((lte 10) ""))))
 
 (deftest test-over
   (is (= over gt)))
@@ -115,4 +115,4 @@
   (is ((between 1 10) "10"))
   (is (not ((between 1 10) "0")))
   (is (not ((between 1 10) "11")))
-  (is (thrown? AssertionError ((between 1 10) ""))))
+  (is (not ((between 1 10) ""))))


### PR DESCRIPTION
The following code will fail with an `AssertionError` using the
previous implementation. This seems a bit unfortunate because it
forces the caller of to split validation into multiple calls to
avoid an `AssertionError`.

```
( validate {}
  [ :email present? "Email is required" ]
  [ :email email-address? "Email address invalid" ] )
```

The above example will now return.

```
{ :email [ "Email is required" "Email address invalid" ] }
```
